### PR TITLE
Update usage example.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,7 +21,6 @@ A flexible neural network library for Node.js and the browser. Check out a live 
 
 ```js
 var Mind = require('node-mind');
-var mind = Mind();
 
 /**
  * Letters.


### PR DESCRIPTION
Remove duplicate variable declaration in usage example. `mind` is already declared on lined 65:

``` js
var mind = Mind()
  .learn([...
```
